### PR TITLE
Enhance shadow DOM support in API and examples:

### DIFF
--- a/docs/demos/DemoShadowRoot.vue
+++ b/docs/demos/DemoShadowRoot.vue
@@ -1,0 +1,119 @@
+<template>
+  <div>
+    <h3>Shadow DOM Selection</h3>
+    <p>This demo shows selection functionality within a Shadow DOM. The orange items are inside a shadow root.</p>
+    <div ref="shadowHost" class="shadow-host"></div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import {onMounted, useTemplateRef} from 'vue';
+import SelectionArea from '@viselect/vanilla';
+
+const shadowHost = useTemplateRef('shadowHost');
+
+onMounted(() => {
+  // Create shadow root
+  const host = shadowHost.value;
+  const shadowRoot = host.attachShadow({ mode: 'open' });
+  
+  // Add content to shadow root
+  shadowRoot.innerHTML = `
+    <style>
+      .container { 
+        display: flex; 
+        flex-wrap: wrap; 
+        gap: 10px; 
+        padding: 20px; 
+        border: 2px solid #ff9800; 
+        border-radius: 15px;
+        user-select: none;
+      }
+      .item { 
+        width: 50px; 
+        height: 50px; 
+        background: #fff3e0; 
+        border: 1px solid #ffcc02; 
+        border-radius: 5px;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 12px;
+        color: #666;
+      }
+      .item.selected { 
+        background: #ff9800; 
+        color: white;
+      }
+      .selection-area { 
+        background: rgba(255, 152, 0, 0.2); 
+        border: 1px solid #ff9800; 
+        border-radius: 4px;
+      }
+    </style>
+    <div class="container">
+      <div class="item">1</div>
+      <div class="item">2</div>
+      <div class="item">3</div>
+      <div class="item">4</div>
+      <div class="item">5</div>
+      <div class="item">6</div>
+      <div class="item">7</div>
+      <div class="item">8</div>
+      <div class="item">9</div>
+      <div class="item">10</div>
+      <div class="item">11</div>
+      <div class="item">12</div>
+    </div>
+  `;
+  
+  // Initialize selection within shadow root
+  const selection = new SelectionArea({
+    selectables: ['.item'],
+    boundaries: ['.container'],
+    startAreas: ['.container'], // Important for shadow root context
+    container: '.container',
+    document: shadowRoot, // Pass the shadow root here
+    selectionAreaClass: 'selection-area'
+  });
+  
+  // Set up event handlers
+  selection.on('start', ({ store, event }) => {
+    console.log('Shadow root selection started');
+    // Clear previous selection unless modifier key is pressed
+    if (!event.ctrlKey && !event.metaKey && !event.shiftKey) {
+      store.stored.forEach(el => el.classList.remove('selected'));
+      selection.clearSelection();
+    }
+  });
+  
+  selection.on('move', ({ store: { changed: { added, removed } } }) => {
+    console.log('Shadow root selection moved:', { added: added.length, removed: removed.length });
+    added.forEach(el => el.classList.add('selected'));
+    removed.forEach(el => el.classList.remove('selected'));
+  });
+  
+  selection.on('stop', () => {
+    console.log('Shadow root selection stopped');
+  });
+});
+</script>
+
+<style scoped>
+.shadow-host {
+  margin: 20px 0;
+  min-height: 200px;
+}
+
+h3 {
+  margin-bottom: 10px;
+  color: var(--vp-c-text-1);
+}
+
+p {
+  margin-bottom: 15px;
+  color: var(--vp-c-text-2);
+  font-size: 14px;
+}
+</style> 

--- a/docs/demos/DemoShadowRootTransformed.vue
+++ b/docs/demos/DemoShadowRootTransformed.vue
@@ -1,0 +1,249 @@
+<template>
+  <div>
+    <h3>Shadow DOM with Transformed Elements</h3>
+    <p>This demo shows selection functionality within a Shadow DOM with transformed/zoomed elements. The canvas is zoomed and translated, and elements can overflow outside the canvas boundaries.</p>
+    
+    <div class="demo-container">
+      <div class="test-section">
+        <h4>Test 1: Canvas as Boundary</h4>
+        <p>Uses the transformed canvas as both start area and boundary.</p>
+        <div ref="shadowHost1" class="shadow-host"></div>
+        <div class="status" :class="status1.class">{{ status1.message }}</div>
+      </div>
+      
+      <div class="test-section">
+        <h4>Test 2: Wrapper as Boundary</h4>
+        <p>Uses the wrapper as boundary, allowing selection from both wrapper and canvas.</p>
+        <div ref="shadowHost2" class="shadow-host"></div>
+        <div class="status" :class="status2.class">{{ status2.message }}</div>
+      </div>
+      
+      <div class="test-section">
+        <h4>Test 3: Automatic Defaults</h4>
+        <p>No explicit configuration - relies on automatic defaults for shadow DOM.</p>
+        <div ref="shadowHost3" class="shadow-host"></div>
+        <div class="status" :class="status3.class">{{ status3.message }}</div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import {onMounted, useTemplateRef, ref} from 'vue';
+import SelectionArea from '@viselect/vanilla';
+
+const shadowHost1 = useTemplateRef('shadowHost1');
+const shadowHost2 = useTemplateRef('shadowHost2');
+const shadowHost3 = useTemplateRef('shadowHost3');
+
+const status1 = ref({ message: 'Initializing...', class: '' });
+const status2 = ref({ message: 'Initializing...', class: '' });
+const status3 = ref({ message: 'Initializing...', class: '' });
+
+function createShadowDOM(host: HTMLElement, status: any, config: any) {
+  // Create shadow root
+  const shadowRoot = host.attachShadow({ mode: 'open' });
+  
+  // Add content to shadow root
+  shadowRoot.innerHTML = `
+    <style>
+      .wrapper {
+        width: 100%;
+        height: 100%;
+        position: relative;
+        overflow: hidden;
+        background: linear-gradient(45deg, #f0f0f0, #e0e0e0);
+        border-radius: 8px;
+      }
+      
+      .canvas {
+        width: 100%;
+        height: 100%;
+        transform-origin: top left;
+        will-change: transform;
+        backface-visibility: hidden;
+        -webkit-font-smoothing: subpixel-antialiased;
+        display: flex;
+        flex-direction: column;
+        transform: translate(-30px, 20px) scale(1.1);
+        background: rgba(255, 255, 255, 0.9);
+        border-radius: 8px;
+        padding: 15px;
+        user-select: none;
+      }
+      
+      .item {
+        width: 35px;
+        height: 35px;
+        margin: 3px;
+        background: #4CAF50;
+        border-radius: 4px;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: white;
+        font-weight: bold;
+        font-size: 11px;
+        transition: background-color 0.2s;
+      }
+      
+      .item.selected {
+        background: #2196F3;
+        box-shadow: 0 2px 4px rgba(33, 150, 243, 0.3);
+      }
+      
+      .item:hover {
+        background: #45a049;
+      }
+      
+      .item.selected:hover {
+        background: #1976D2;
+      }
+      
+      .selection-area {
+        background: rgba(102, 110, 255, 0.16);
+        border: 1px solid rgb(62, 99, 221);
+        border-radius: 0.15em;
+      }
+    </style>
+    <div class="wrapper">
+      <div class="canvas">
+        <div class="item" data-id="1">1</div>
+        <div class="item" data-id="2">2</div>
+        <div class="item" data-id="3">3</div>
+        <div class="item" data-id="4">4</div>
+        <div class="item" data-id="5">5</div>
+        <div class="item" data-id="6">6</div>
+        <div class="item" data-id="7">7</div>
+        <div class="item" data-id="8">8</div>
+        <div class="item" data-id="9">9</div>
+        <div class="item" data-id="10">10</div>
+      </div>
+    </div>
+  `;
+  
+  // Get elements
+  const wrapper = shadowRoot.querySelector('.wrapper');
+  const canvas = shadowRoot.querySelector('.canvas');
+  const items = shadowRoot.querySelectorAll('.item');
+  
+  // Initialize selection area
+  const selection = new SelectionArea({
+    selectables: ['[data-id]'],
+    document: shadowRoot,
+    selectionAreaClass: 'selection-area',
+    ...config
+  });
+  
+  // Event handlers
+  selection.on('start', ({ store, event }) => {
+    if (!event?.ctrlKey && !event?.metaKey && !event?.shiftKey) {
+      store.stored.forEach(el => el.classList.remove('selected'));
+      selection.clearSelection();
+    }
+  });
+  
+  selection.on('move', ({ store: { changed: { added, removed } } }) => {
+    added.forEach(el => el.classList.add('selected'));
+    removed.forEach(el => el.classList.remove('selected'));
+  });
+  
+  selection.on('stop', ({ store }) => {
+    const selectedCount = store.stored.length;
+    status.message = `Selection complete! ${selectedCount} items selected.`;
+    status.class = 'success';
+  });
+  
+  // Test status
+  status.message = 'Shadow DOM created successfully. Try selecting items by clicking and dragging!';
+  status.class = 'success';
+  
+  return { selection, wrapper, canvas, items };
+}
+
+onMounted(() => {
+  // Test 1: Canvas as start area and boundary
+  if (shadowHost1.value) {
+    createShadowDOM(shadowHost1.value, status1, {
+      startAreas: ['.canvas'],
+      boundaries: ['.canvas']
+    });
+  }
+  
+  // Test 2: Wrapper as boundary, canvas as start area
+  if (shadowHost2.value) {
+    createShadowDOM(shadowHost2.value, status2, {
+      startAreas: ['.canvas'],
+      boundaries: ['.wrapper']
+    });
+  }
+  
+  // Test 3: Automatic defaults
+  if (shadowHost3.value) {
+    createShadowDOM(shadowHost3.value, status3, {
+      // No startAreas or boundaries specified - uses automatic defaults
+    });
+  }
+});
+</script>
+
+<style scoped>
+.demo-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 20px;
+  margin-top: 20px;
+}
+
+.test-section {
+  background: white;
+  border-radius: 8px;
+  padding: 15px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.test-section h4 {
+  margin: 0 0 8px 0;
+  color: #333;
+  font-size: 14px;
+}
+
+.test-section p {
+  margin: 0 0 12px 0;
+  color: #666;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.shadow-host {
+  width: 100%;
+  height: 200px;
+  border: 2px solid #ddd;
+  border-radius: 8px;
+  position: relative;
+  overflow: hidden;
+  background: #fafafa;
+  margin-bottom: 10px;
+}
+
+.status {
+  padding: 8px;
+  border-radius: 4px;
+  font-family: monospace;
+  font-size: 11px;
+  line-height: 1.3;
+}
+
+.status.success {
+  background: #d4edda;
+  color: #155724;
+  border: 1px solid #c3e6cb;
+}
+
+.status.error {
+  background: #f8d7da;
+  color: #721c24;
+  border: 1px solid #f5c6cb;
+}
+</style> 

--- a/docs/pages/api-reference.md
+++ b/docs/pages/api-reference.md
@@ -304,7 +304,7 @@ interface SelectionOptions {
   selectionAreaClass: string;
   selectionContainerClass: string | undefined;
   container: Quantify<string | HTMLElement>;
-  document: Document;
+  document: Document | ShadowRoot;
   selectables: Quantify<string>;
   startAreas: Quantify<string | HTMLElement>;
   boundaries: Quantify<string | HTMLElement>;
@@ -317,9 +317,12 @@ interface SelectionOptions {
 
 Type of what can be passed to the `SelectionArea` constructor.
 
+> [!NOTE]
+> The `document` property supports both `Document` and `ShadowRoot` types, allowing you to use Viselect within shadow DOM components. Note that while ShadowRoot is used for querying elements, element creation still happens through the Document interface.
+
 ```typescript
 type PartialSelectionOptions = DeepPartial<Omit<SelectionOptions, 'document'>> & {
-  document?: Document;
+  document?: Document | ShadowRoot;
 };
 ```
 

--- a/docs/pages/examples.md
+++ b/docs/pages/examples.md
@@ -6,32 +6,251 @@ outline: deep
 <script setup>
 import DemoSimple from '../demos/DemoSimple.vue';
 import DemoScrollable from '../demos/DemoScrollable.vue';
+import DemoShadowRoot from '../demos/DemoShadowRoot.vue';
 </script>
 
 # Examples
 
-> [!TIP]
-> This document provides a few examples of how this library can be used in practice.
-> Head over to [Quickstart](./quickstart.md) to get started!
+This page contains various examples of how to use Viselect in different scenarios.
 
-### Simple Selection
+## Basic Usage
 
-A single, simple box with a standard behaviour as you know it from your trusty file explorer.
-Press `Ctrl` / `Cmd` to select multiple items, or deselect items by clicking on them again.
-Press `Shift` to select a range of items after selecting one ore more before.
+The most basic usage involves selecting elements within a container:
 
 <DemoSimple />
 
 > You can find the source code for this example [here](https://github.com/simonwep/viselect/blob/master/docs/demos/DemoSimple.vue).
-> Under [Quickstart](./quickstart.md) you can find a step-by-step guide on how to create this example from scratch!
 
-### Scrollable Container
+```ts
+import SelectionArea from '@viselect/vanilla';
 
-A container that can be scrolled in both directions.
-The selection area will automatically adjust to the scroll position and size of the container.
+const selection = new SelectionArea({
+  selectables: ['.item'],
+  boundaries: ['.container']
+});
+
+selection.on('move', ({ store: { changed: { added, removed } } }) => {
+  added.forEach(el => el.classList.add('selected'));
+  removed.forEach(el => el.classList.remove('selected'));
+});
+```
+
+## Shadow Root Support
+
+Viselect fully supports shadow DOM. You can pass a `ShadowRoot` instance as the `document` option. This is particularly useful for web components and encapsulated UI elements.
+
+<DemoShadowRoot />
+
+> You can find the source code for this example [here](https://github.com/simonwep/viselect/blob/master/docs/demos/DemoShadowRoot.vue).
+
+### Key Points for Shadow Root Usage:
+
+1. **Pass the ShadowRoot**: Use the `document` option to specify the shadow root
+2. **Set startAreas**: Important to specify start areas within the shadow root context
+3. **Element Creation**: ShadowRoot is used for querying, but element creation still happens through Document
+4. **Event Handling**: Events are properly bound to the shadow root for seamless interaction
+
+```ts
+import SelectionArea from '@viselect/vanilla';
+
+// Create a shadow root
+const host = document.getElementById('my-host');
+const shadowRoot = host.attachShadow({ mode: 'open' });
+
+// Add content to shadow root
+shadowRoot.innerHTML = `
+  <style>
+    .container { display: flex; flex-wrap: wrap; gap: 10px; }
+    .item { width: 50px; height: 50px; background: #f0f0f0; }
+    .item.selected { background: #4CAF50; }
+  </style>
+  <div class="container">
+    <div class="item"></div>
+    <div class="item"></div>
+    <div class="item"></div>
+  </div>
+`;
+
+// Initialize selection within shadow root
+const selection = new SelectionArea({
+  selectables: ['.item'],
+  boundaries: ['.container'],
+  startAreas: ['.container'], // Important for shadow root context
+  document: shadowRoot, // Pass the shadow root here
+  selectionAreaClass: 'selection-area'
+});
+
+selection.on('move', ({ store: { changed: { added, removed } } }) => {
+  added.forEach(el => el.classList.add('selected'));
+  removed.forEach(el => el.classList.remove('selected'));
+});
+```
+
+## Multiple Selection Areas
+
+You can have multiple selection areas on the same page:
+
+```ts
+import SelectionArea from '@viselect/vanilla';
+
+// First selection area
+const selection1 = new SelectionArea({
+  selectables: ['.area1 .item'],
+  boundaries: ['.area1'],
+  selectionAreaClass: 'selection-area-1'
+});
+
+// Second selection area
+const selection2 = new SelectionArea({
+  selectables: ['.area2 .item'],
+  boundaries: ['.area2'],
+  selectionAreaClass: 'selection-area-2'
+});
+
+// Handle events for both
+[selection1, selection2].forEach(selection => {
+  selection.on('move', ({ store: { changed: { added, removed } } }) => {
+    added.forEach(el => el.classList.add('selected'));
+    removed.forEach(el => el.classList.remove('selected'));
+  });
+});
+```
+
+## Custom Triggers
+
+You can customize which mouse buttons trigger selection:
+
+```ts
+import SelectionArea from '@viselect/vanilla';
+
+const selection = new SelectionArea({
+  selectables: ['.item'],
+  boundaries: ['.container'],
+  behaviour: {
+    // Only right-click triggers selection
+    triggers: [2],
+    // Or require modifier keys
+    // triggers: [{ button: 0, modifiers: ['ctrl'] }]
+  }
+});
+```
+
+## Touch Support
+
+Viselect has built-in touch support for mobile devices:
+
+```ts
+import SelectionArea from '@viselect/vanilla';
+
+const selection = new SelectionArea({
+  selectables: ['.item'],
+  boundaries: ['.container'],
+  features: {
+    touch: true, // Enable touch support (default: true)
+    singleTap: {
+      allow: true, // Allow single tap selection
+      intersect: 'touch' // Use touch intersection instead of native
+    }
+  }
+});
+```
+
+## Scrollable Containers
+
+Viselect automatically handles scrollable containers. Try scrolling and selecting in the demo below:
 
 <DemoScrollable />
 
-> You can find the source code for this example [here](https://github.com/simonwep/viselect/blob/master/docs/demos/DemoScrollable.vue)
+> You can find the source code for this example [here](https://github.com/simonwep/viselect/blob/master/docs/demos/DemoScrollable.vue).
+
+```ts
+import SelectionArea from '@viselect/vanilla';
+
+const selection = new SelectionArea({
+  selectables: ['.item'],
+  boundaries: ['.scrollable-container'],
+  behaviour: {
+    scrolling: {
+      speedDivider: 10, // Scroll speed divisor
+      manualSpeed: 750, // Manual scroll speed
+      startScrollMargins: { x: 20, y: 20 } // Margins to start scrolling
+    }
+  }
+});
+```
+
+## Range Selection
+
+Enable range selection with Shift+Click:
+
+```ts
+import SelectionArea from '@viselect/vanilla';
+
+const selection = new SelectionArea({
+  selectables: ['.item'],
+  boundaries: ['.container'],
+  features: {
+    range: true // Enable range selection (default: true)
+  }
+});
+
+selection.on('start', ({ store, event }) => {
+  // Clear previous selection unless modifier key is pressed
+  if (!event.ctrlKey && !event.metaKey && !event.shiftKey) {
+    store.stored.forEach(el => el.classList.remove('selected'));
+    selection.clearSelection();
+  }
+});
+```
+
+## Custom Overlap Behavior
+
+Control how overlapping selections behave:
+
+```ts
+import SelectionArea from '@viselect/vanilla';
+
+const selection = new SelectionArea({
+  selectables: ['.item'],
+  boundaries: ['.container'],
+  behaviour: {
+    overlap: 'invert' // 'invert', 'keep', or 'drop'
+  }
+});
+```
+
+## Event Handling
+
+Complete example with all events:
+
+```ts
+import SelectionArea from '@viselect/vanilla';
+
+const selection = new SelectionArea({
+  selectables: ['.item'],
+  boundaries: ['.container']
+});
+
+selection
+  .on('beforestart', ({ event }) => {
+    console.log('About to start selection', event);
+    // Return false to cancel selection
+  })
+  .on('beforedrag', ({ event }) => {
+    console.log('About to start dragging', event);
+    // Return false to cancel drag
+  })
+  .on('start', ({ store, event }) => {
+    console.log('Selection started', store, event);
+  })
+  .on('move', ({ store: { changed: { added, removed } } }) => {
+    console.log('Selection changed', { added, removed });
+    added.forEach(el => el.classList.add('selected'));
+    removed.forEach(el => el.classList.remove('selected'));
+  })
+  .on('stop', ({ store, event }) => {
+    console.log('Selection stopped', store, event);
+  });
+```
 
 

--- a/docs/pages/examples.md
+++ b/docs/pages/examples.md
@@ -7,6 +7,7 @@ outline: deep
 import DemoSimple from '../demos/DemoSimple.vue';
 import DemoScrollable from '../demos/DemoScrollable.vue';
 import DemoShadowRoot from '../demos/DemoShadowRoot.vue';
+import DemoShadowRootTransformed from '../demos/DemoShadowRootTransformed.vue';
 </script>
 
 # Examples
@@ -43,12 +44,20 @@ Viselect fully supports shadow DOM. You can pass a `ShadowRoot` instance as the 
 
 > You can find the source code for this example [here](https://github.com/simonwep/viselect/blob/master/docs/demos/DemoShadowRoot.vue).
 
+## Shadow DOM with Transformed Elements
+
+Viselect supports shadow DOM with transformed/zoomed elements. This is particularly useful for applications with complex layouts where elements can be transformed and overflow their containers.
+
+<DemoShadowRootTransformed />
+
+> You can find the source code for this example [here](https://github.com/simonwep/viselect/blob/master/docs/demos/DemoShadowRootTransformed.vue).
+
 ### Key Points for Shadow Root Usage:
 
 1. **Pass the ShadowRoot**: Use the `document` option to specify the shadow root
-2. **Set startAreas**: Important to specify start areas within the shadow root context
+2. **Automatic Defaults**: The library automatically adjusts defaults for shadow DOM contexts
 3. **Element Creation**: ShadowRoot is used for querying, but element creation still happens through Document
-4. **Event Handling**: Events are properly bound to the shadow root for seamless interaction
+4. **Event Handling**: Events are properly bound to both shadow root and shadow host for seamless interaction
 
 ```ts
 import SelectionArea from '@viselect/vanilla';
@@ -75,7 +84,7 @@ shadowRoot.innerHTML = `
 const selection = new SelectionArea({
   selectables: ['.item'],
   boundaries: ['.container'],
-  startAreas: ['.container'], // Important for shadow root context
+  // startAreas is optional - defaults are automatically adjusted for shadow DOM
   document: shadowRoot, // Pass the shadow root here
   selectionAreaClass: 'selection-area'
 });

--- a/docs/pages/quickstart.md
+++ b/docs/pages/quickstart.md
@@ -203,6 +203,7 @@ const selection = new SelectionArea({
   // document object - if you want to use it within an embed document (or iframe).
   // For shadow DOM support, pass the ShadowRoot instance here.
   // Both Document and ShadowRoot are supported.
+  // When using ShadowRoot, the library automatically adjusts defaults for shadow DOM contexts.
   document: window.document,
 
   // Query selectors for elements which can be selected.

--- a/docs/pages/quickstart.md
+++ b/docs/pages/quickstart.md
@@ -201,7 +201,8 @@ const selection = new SelectionArea({
   container: 'body',
 
   // document object - if you want to use it within an embed document (or iframe).
-  // If you're inside of a shadow-dom make sure to specify the shadow root here.
+  // For shadow DOM support, pass the ShadowRoot instance here.
+  // Both Document and ShadowRoot are supported.
   document: window.document,
 
   // Query selectors for elements which can be selected.

--- a/packages/vanilla/src/index.ts
+++ b/packages/vanilla/src/index.ts
@@ -379,7 +379,6 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
             if (containerElement) {
                 containerElement.appendChild(this._clippingElement);
             } else {
-                console.warn('Container not found, falling back to document body');
                 getDocument(this._options.document).body.appendChild(this._clippingElement);
             }
 

--- a/packages/vanilla/src/index.ts
+++ b/packages/vanilla/src/index.ts
@@ -513,8 +513,10 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
                             const transformedChild = transformedChildren[0];
                             this._selectables = this._selectables.filter(s => transformedChild.contains(s));
                         } else {
-                            // Fallback to original logic
-                            this._selectables = this._selectables.filter(s => this._targetElement!.contains(s));
+                            // For shadow roots, if the target element is the shadow host (wrapper),
+                            // we should NOT filter by containment because contains() doesn't work across shadow boundaries
+                            // The selectable elements are inside the shadow root, not the shadow host
+                            // Don't filter - keep all selectables when using shadow host as boundary
                         }
                     }
                 } else {
@@ -712,6 +714,8 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
         const {x1, y1} = _areaLocation;
         let {x2, y2} = _areaLocation;
 
+
+
         const {behaviour: {scrolling: {startScrollMargins}}} = _options;
 
         if (x2 < _targetRect.left + startScrollMargins.x) {
@@ -751,7 +755,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
         style.top = `${y}px`;
         style.width = `${width}px`;
         style.height = `${height}px`;
-        
+
 
     }
 
@@ -826,6 +830,8 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
         for (let i = 0; i < _selectables.length; i++) {
             const node = _selectables[i];
             const nodeRect = node.getBoundingClientRect();
+
+
 
             // Check if the area intersects an element
             if (intersects(_areaRect, nodeRect, intersect)) {

--- a/packages/vanilla/src/index.ts
+++ b/packages/vanilla/src/index.ts
@@ -138,6 +138,21 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
             }
         };
 
+        // Special handling for shadow roots - adjust defaults if not explicitly set
+        if (this._options.document instanceof ShadowRoot) {
+            // If startAreas is still the default 'html', replace with shadow root host
+            const startAreasArray = Array.isArray(this._options.startAreas) ? this._options.startAreas : [this._options.startAreas];
+            if (startAreasArray.length === 1 && startAreasArray[0] === 'html') {
+                this._options.startAreas = [this._options.document.host as HTMLElement];
+            }
+            
+            // If boundaries is still the default 'html', replace with shadow root host
+            const boundariesArray = Array.isArray(this._options.boundaries) ? this._options.boundaries : [this._options.boundaries];
+            if (boundariesArray.length === 1 && boundariesArray[0] === 'html') {
+                this._options.boundaries = [this._options.document.host as HTMLElement];
+            }
+        }
+
         // Bind locale functions to instance
         /* eslint-disable @typescript-eslint/no-explicit-any */
         for (const key of Object.getOwnPropertyNames(Object.getPrototypeOf(this))) {
@@ -205,6 +220,14 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
         if (features.touch) {
             fn(eventTarget, 'touchstart', this._onTapStart, {passive: false});
         }
+        
+        // For shadow roots, also bind to the shadow host to capture clicks on the wrapper
+        if (doc instanceof ShadowRoot) {
+            fn(doc.host, 'mousedown', this._onTapStart);
+            if (features.touch) {
+                fn(doc.host, 'touchstart', this._onTapStart, {passive: false});
+            }
+        }
     }
 
     _onTapStart(evt: MouseEvent | TouchEvent, silent = false): void {
@@ -226,16 +249,58 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
         // Find start-areas and boundaries
         const resolvedStartAreas = selectAll(startAreas, doc);
         const resolvedBoundaries = selectAll(boundaries, doc);
+        
+
 
         // Check in which container the user currently acts
         this._targetElement = resolvedBoundaries.find(el =>
             intersects(el.getBoundingClientRect(), targetBoundingClientRect)
         );
+        
+        // For shadow roots, if no target element found by intersection, 
+        // try to find one that contains the clicked element
+        if (doc instanceof ShadowRoot && !this._targetElement) {
+            this._targetElement = resolvedBoundaries.find(boundary => {
+                let element: HTMLElement | null = target;
+                while (element) {
+                    if (element === boundary) return true;
+                    element = element.parentElement;
+                }
+                return false;
+            });
+        }
 
         // Check if the area starts in one of the start areas / boundaries
         const evtPath = evt.composedPath();
         const targetStartArea = resolvedStartAreas.find(el => evtPath.includes(el));
         this._targetBoundary = resolvedBoundaries.find(el => evtPath.includes(el));
+        
+        // For shadow roots with transformed elements, if we found a start area but no boundary,
+        // try to find a boundary that contains the start area or is the parent of the start area
+        if (doc instanceof ShadowRoot && targetStartArea && !this._targetBoundary) {
+            this._targetBoundary = resolvedBoundaries.find(boundary => {
+                // Check if boundary contains the start area
+                if (boundary.contains(targetStartArea)) {
+                    return true;
+                }
+                
+                // Check if start area contains the boundary
+                if (targetStartArea.contains(boundary)) {
+                    return true;
+                }
+                
+                // Check if they have a parent-child relationship
+                let parent = targetStartArea.parentElement;
+                while (parent) {
+                    if (parent === boundary) {
+                        return true;
+                    }
+                    parent = parent.parentElement;
+                }
+                
+                return false;
+            });
+        }
 
         if (!this._targetElement || !targetStartArea || !this._targetBoundary) {
             return;
@@ -363,9 +428,9 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
             (typeof startThreshold === 'object' && abs(x - x1) >= (startThreshold as Coordinates).x || abs(y - y1) >= (startThreshold as Coordinates).y)
         ) {
             // For shadow roots, we need to unbind from both shadow root and main document
-            const {document: doc} = this._options;
-            const eventTarget = doc instanceof ShadowRoot ? doc : getDocument(doc);
-            const mainDocument = getDocument(doc);
+            const {document: docOpt1} = this._options;
+            const eventTarget = docOpt1 instanceof ShadowRoot ? docOpt1 : getDocument(docOpt1);
+            const mainDocument = getDocument(docOpt1);
             
             off(eventTarget, ['mousemove', 'touchmove'], this._delayedTapMove, {passive: false});
             off(mainDocument, ['mousemove', 'touchmove'], this._delayedTapMove, {passive: false});
@@ -383,12 +448,20 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
             css(this._area, 'display', 'block');
 
             // Append selection-area to the dom
-            // Use the same document context for finding the container
-            const containerElement = selectAll(container, this._options.document)[0];
+            // For shadow roots, append to the main document body to avoid transform issues
+            const {document: docOpt2} = this._options;
+            let containerElement = selectAll(container, docOpt2)[0];
+            
+            // For shadow roots, always append to the main document body
+            // to avoid transform coordinate system issues
+            if (docOpt2 instanceof ShadowRoot) {
+                containerElement = getDocument(docOpt2).body;
+            }
+            
             if (containerElement) {
                 containerElement.appendChild(this._clippingElement);
             } else {
-                getDocument(this._options.document).body.appendChild(this._clippingElement);
+                getDocument(docOpt2).body.appendChild(this._clippingElement);
             }
 
             this.resolveSelectables();
@@ -412,14 +485,44 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
                 // Detect keyboard scrolling
                 on(this._options.document, 'keydown', this._keyboardScroll, {passive: false});
 
-
                 /**
                  * The selection-area will also cover another element
                  * out of the current scrollable parent. So find all elements
                  * that are in the current scrollable element. Now these are
                  * the only selectables instead of all.
                  */
-                this._selectables = this._selectables.filter(s => this._targetElement!.contains(s));
+                
+                // Special handling for shadow roots with transformed elements
+                const {document: doc} = this._options;
+                if (doc instanceof ShadowRoot) {
+                    // For shadow roots, if we have a start area that's different from the boundary,
+                    // we should filter based on the start area instead of the boundary
+                    const resolvedStartAreas = selectAll(this._options.startAreas, doc);
+                    const startArea = resolvedStartAreas[0];
+                    
+                    if (startArea && startArea !== this._targetElement) {
+                        this._selectables = this._selectables.filter(s => startArea.contains(s));
+                    } else {
+                        // When start area and target element are the same (e.g., both wrapper),
+                        // we need to handle the case where selectables are in a transformed child
+                        // Look for transformed elements within the target that might contain selectables
+                        const transformedChildren = Array.from(this._targetElement!.querySelectorAll('[style*="transform"]'));
+                        
+                        if (transformedChildren.length > 0) {
+                            // Use the first transformed child as the containment reference
+                            const transformedChild = transformedChildren[0];
+                            this._selectables = this._selectables.filter(s => transformedChild.contains(s));
+                        } else {
+                            // Fallback to original logic
+                            this._selectables = this._selectables.filter(s => this._targetElement!.contains(s));
+                        }
+                    }
+                } else {
+                    // Original logic for regular documents
+                    this._selectables = this._selectables.filter(s => this._targetElement!.contains(s));
+                }
+                
+
             }
 
             // Re-setup selection area and fire event
@@ -648,6 +751,8 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
         style.top = `${y}px`;
         style.width = `${width}px`;
         style.height = `${height}px`;
+        
+
     }
 
     _onTapStop(evt: MouseEvent | TouchEvent | null, silent: boolean): void {
@@ -668,6 +773,13 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
         off(eventTarget, ['mouseup', 'touchcancel', 'touchend'], this._onTapStop);
         off(mainDocument, ['mouseup', 'touchcancel', 'touchend'], this._onTapStop);
         off(eventTarget, 'scroll', this._onScroll);
+        
+        // For shadow roots, also unbind from the shadow host
+        if (doc instanceof ShadowRoot) {
+            off(doc.host, ['mousemove', 'touchmove'], this._delayedTapMove);
+            off(doc.host, ['touchmove', 'mousemove'], this._onTapMove);
+            off(doc.host, ['mouseup', 'touchcancel', 'touchend'], this._onTapStop);
+        }
 
         // Keep selection until the next time
         this._keepSelection();
@@ -708,12 +820,15 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
         const added: Element[] = [];
         const removed: Element[] = [];
 
+
+
         // Find newly selected elements
         for (let i = 0; i < _selectables.length; i++) {
             const node = _selectables[i];
+            const nodeRect = node.getBoundingClientRect();
 
             // Check if the area intersects an element
-            if (intersects(_areaRect, node.getBoundingClientRect(), intersect)) {
+            if (intersects(_areaRect, nodeRect, intersect)) {
 
                 // Check if the element wasn't present in the last selection.
                 if (!selected.includes(node)) {

--- a/packages/vanilla/src/index.ts
+++ b/packages/vanilla/src/index.ts
@@ -1,26 +1,26 @@
-import {EventTarget} from './EventEmitter';
-import type {AreaLocation, Coordinates, ScrollEvent, SelectionEvents, SelectionOptions, SelectionStore} from './types';
-import {PartialSelectionOptions} from './types';
-import {css} from './utils/css';
-import {domRect} from './utils/domRect';
-import {Frames, frames} from './utils/frames';
-import {intersects} from './utils/intersects';
-import {isSafariBrowser, isTouchDevice} from './utils/browser';
-import {on, off, simplifyEvent} from './utils/events';
-import {selectAll, SelectAllSelectors} from './utils/selectAll';
-import {matchesTrigger} from './utils/matchesTrigger';
+import { EventTarget } from './EventEmitter';
+import type { AreaLocation, Coordinates, ScrollEvent, SelectionEvents, SelectionOptions, SelectionStore } from './types';
+import { PartialSelectionOptions } from './types';
+import { css } from './utils/css';
+import { domRect } from './utils/domRect';
+import { Frames, frames } from './utils/frames';
+import { intersects } from './utils/intersects';
+import { isSafariBrowser, isTouchDevice } from './utils/browser';
+import { on, off, simplifyEvent } from './utils/events';
+import { selectAll, SelectAllSelectors } from './utils/selectAll';
+import { matchesTrigger } from './utils/matchesTrigger';
 
 // Re-export types
 export * from './types';
 
 // Some var shorting for better compression and readability
-const {abs, max, min, ceil} = Math;
+const { abs, max, min, ceil } = Math;
 
 const makeSelectionStore = (stored: Element[] = []): SelectionStore => ({
     stored,
     selected: [],
     touched: [],
-    changed: {added: [], removed: []}
+    changed: { added: [], removed: [] }
 });
 
 // Helper function to get the scrolling element from a document or shadow root
@@ -28,7 +28,7 @@ const getScrollingElement = (doc: Document | ShadowRoot): Element => {
     if ('scrollingElement' in doc && doc.scrollingElement) {
         return doc.scrollingElement;
     }
-    
+
     // For shadow roots, we need to find the scrolling element within the shadow DOM
     if (doc instanceof ShadowRoot) {
         // Try to find a scrollable element within the shadow root
@@ -39,7 +39,7 @@ const getScrollingElement = (doc: Document | ShadowRoot): Element => {
         // Fallback to the host element
         return doc.host;
     }
-    
+
     // For regular documents, fallback to body
     return doc.body;
 };
@@ -75,7 +75,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
     private _latestElement?: Element;
 
     // Dynamically constructed area rect
-    private _areaLocation: AreaLocation = {y1: 0, x2: 0, y2: 0, x1: 0};
+    private _areaLocation: AreaLocation = { y1: 0, x2: 0, y2: 0, x1: 0 };
     private _areaRect = domRect();
 
     // If a single click is being performed, it's a single-click until the user dragged the mouse
@@ -85,11 +85,11 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
     // Required data for scrolling
     private _scrollAvailable = true;
     private _scrollingActive = false;
-    private _scrollSpeed: Coordinates = {x: 0, y: 0};
-    private _scrollDelta: Coordinates = {x: 0, y: 0};
+    private _scrollSpeed: Coordinates = { x: 0, y: 0 };
+    private _scrollDelta: Coordinates = { x: 0, y: 0 };
 
     // Required for keydown scrolling
-    private _lastMousePosition = {x: 0, y: 0};
+    private _lastMousePosition = { x: 0, y: 0 };
 
     constructor(opt: PartialSelectionOptions) {
         super();
@@ -112,7 +112,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
                 startThreshold: opt.behaviour?.startThreshold ?
                     typeof opt.behaviour.startThreshold === 'number' ?
                         opt.behaviour.startThreshold :
-                        {x: 10, y: 10, ...opt.behaviour.startThreshold} : {x: 10, y: 10},
+                        { x: 10, y: 10, ...opt.behaviour.startThreshold } : { x: 10, y: 10 },
                 scrolling: {
                     speedDivider: 10,
                     manualSpeed: 750,
@@ -145,7 +145,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
             if (startAreasArray.length === 1 && startAreasArray[0] === 'html') {
                 this._options.startAreas = [this._options.document.host as HTMLElement];
             }
-            
+
             // If boundaries is still the default 'html', replace with shadow root host
             const boundariesArray = Array.isArray(this._options.boundaries) ? this._options.boundaries : [this._options.boundaries];
             if (boundariesArray.length === 1 && boundariesArray[0] === 'html') {
@@ -161,17 +161,17 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
             }
         }
 
-        const {document: doc, selectionAreaClass, selectionContainerClass} = this._options;
-        
+        const { document: doc, selectionAreaClass, selectionContainerClass } = this._options;
+
         // Ensure we have a valid document or shadow root
         if (!doc) {
             throw new Error('No document or shadow root provided.');
         }
-        
+
         // For element creation, we always need to use the document
         // ShadowRoot doesn't have createElement - it's a Document method
         const documentForCreation = doc instanceof Document ? doc : doc.host.ownerDocument || window.document;
-        
+
         this._area = documentForCreation.createElement('div');
         this._clippingElement = documentForCreation.createElement('div');
         this._clippingElement.appendChild(this._area);
@@ -208,9 +208,9 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
     }
 
     _toggleStartEvents(activate = true): void {
-        const {document: doc, features} = this._options;
+        const { document: doc, features } = this._options;
         const fn = activate ? on : off;
-        
+
         // For shadow roots, we need to bind events to the shadow root itself
         // For regular documents, we bind to the document
         const eventTarget = doc instanceof ShadowRoot ? doc : getDocument(doc);
@@ -218,28 +218,28 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
         fn(eventTarget, 'mousedown', this._onTapStart);
 
         if (features.touch) {
-            fn(eventTarget, 'touchstart', this._onTapStart, {passive: false});
+            fn(eventTarget, 'touchstart', this._onTapStart, { passive: false });
         }
-        
+
         // For shadow roots, also bind to the shadow host to capture clicks on the wrapper
         if (doc instanceof ShadowRoot) {
             fn(doc.host, 'mousedown', this._onTapStart);
             if (features.touch) {
-                fn(doc.host, 'touchstart', this._onTapStart, {passive: false});
+                fn(doc.host, 'touchstart', this._onTapStart, { passive: false });
             }
         }
     }
 
     _onTapStart(evt: MouseEvent | TouchEvent, silent = false): void {
-        
-        const {x, y, target} = simplifyEvent(evt);
-        const {document: doc, startAreas, boundaries, features, behaviour} = this._options;
-        
+
+        const { x, y, target } = simplifyEvent(evt);
+        const { document: doc, startAreas, boundaries, features, behaviour } = this._options;
+
         // Ensure target is an HTMLElement before calling getBoundingClientRect
         if (!(target instanceof HTMLElement)) {
             return;
         }
-        
+
         const targetBoundingClientRect = target.getBoundingClientRect();
 
         if (evt instanceof MouseEvent && !matchesTrigger(evt, behaviour.triggers)) {
@@ -249,14 +249,14 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
         // Find start-areas and boundaries
         const resolvedStartAreas = selectAll(startAreas, doc);
         const resolvedBoundaries = selectAll(boundaries, doc);
-        
+
 
 
         // Check in which container the user currently acts
         this._targetElement = resolvedBoundaries.find(el =>
             intersects(el.getBoundingClientRect(), targetBoundingClientRect)
         );
-        
+
         // For shadow roots, if no target element found by intersection, 
         // try to find one that contains the clicked element
         if (doc instanceof ShadowRoot && !this._targetElement) {
@@ -274,7 +274,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
         const evtPath = evt.composedPath();
         const targetStartArea = resolvedStartAreas.find(el => evtPath.includes(el));
         this._targetBoundary = resolvedBoundaries.find(el => evtPath.includes(el));
-        
+
         // For shadow roots with transformed elements, if we found a start area but no boundary,
         // try to find a boundary that contains the start area or is the parent of the start area
         if (doc instanceof ShadowRoot && targetStartArea && !this._targetBoundary) {
@@ -283,12 +283,12 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
                 if (boundary.contains(targetStartArea)) {
                     return true;
                 }
-                
+
                 // Check if start area contains the boundary
                 if (targetStartArea.contains(boundary)) {
                     return true;
                 }
-                
+
                 // Check if they have a parent-child relationship
                 let parent = targetStartArea.parentElement;
                 while (parent) {
@@ -297,7 +297,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
                     }
                     parent = parent.parentElement;
                 }
-                
+
                 return false;
             });
         }
@@ -310,25 +310,25 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
             return;
         }
 
-        this._areaLocation = {x1: x, y1: y, x2: 0, y2: 0};
+        this._areaLocation = { x1: x, y1: y, x2: 0, y2: 0 };
 
         // Lock scrolling in the target container
         const scrollElement = getScrollingElement(doc);
-        this._scrollDelta = {x: scrollElement.scrollLeft, y: scrollElement.scrollTop};
+        this._scrollDelta = { x: scrollElement.scrollLeft, y: scrollElement.scrollTop };
 
         // To detect single-click
         this._singleClick = true;
-        this.clearSelection(false, true);
+        this.clearSelection(false, true, evt);
 
         // For shadow roots, we need to bind events to the shadow root itself
         // For regular documents, we bind to the document
         const eventTarget = doc instanceof ShadowRoot ? doc : getDocument(doc);
-        
+
         // Also bind to the main document to catch events when mouse moves outside shadow root
         const mainDocument = getDocument(doc);
-        
-        on(eventTarget, ['touchmove', 'mousemove'], this._delayedTapMove, {passive: false});
-        on(mainDocument, ['touchmove', 'mousemove'], this._delayedTapMove, {passive: false});
+
+        on(eventTarget, ['touchmove', 'mousemove'], this._delayedTapMove, { passive: false });
+        on(mainDocument, ['touchmove', 'mousemove'], this._delayedTapMove, { passive: false });
         on(eventTarget, ['mouseup', 'touchcancel', 'touchend'], this._onTapStop);
         on(mainDocument, ['mouseup', 'touchcancel', 'touchend'], this._onTapStop);
         on(eventTarget, 'scroll', this._onScroll);
@@ -340,7 +340,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
     }
 
     _onSingleTap(evt: MouseEvent | TouchEvent): void {
-        const {singleTap: {intersect}, range} = this._options.features;
+        const { singleTap: { intersect }, range } = this._options.features;
         const e = simplifyEvent(evt);
         let target;
 
@@ -349,9 +349,9 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
         } else if (intersect === 'touch') {
             this.resolveSelectables();
 
-            const {x, y} = e;
+            const { x, y } = e;
             target = this._selectables.find(v => {
-                const {right, left, top, bottom} = v.getBoundingClientRect();
+                const { right, left, top, bottom } = v.getBoundingClientRect();
                 return x < right && x > left && y < bottom && y > top;
             });
         }
@@ -374,7 +374,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
                 target = target.parentElement;
             } else {
                 if (!this._targetBoundaryScrolled) {
-                    this.clearSelection();
+                    this.clearSelection(true, false, evt);
                 }
 
                 return;
@@ -383,7 +383,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
         }
 
         // Grab the current store first in case it gets set back
-        const {stored} = this._selection;
+        const { stored } = this._selection;
         this._emitEvent('start', evt);
 
         if (evt.shiftKey && range && this._latestElement) {
@@ -398,7 +398,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
                 (el.compareDocumentPosition(following) & 2)
             ), preceding, following];
 
-            this.select(rangeItems);
+            this.select(rangeItems, false, evt);
             this._latestElement = reference; // the latestElement is by default cleared in .select()
         } else if (
             stored.includes(target) && (
@@ -406,17 +406,17 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
                 stored.every(v => this._selection.stored.includes(v))
             )
         ) {
-            this.deselect(target);
+            this.deselect(target, false, evt);
         } else {
-            this.select(target);
+            this.select(target, false, evt);
             this._latestElement = target;
         }
     }
 
     _delayedTapMove(evt: MouseEvent | TouchEvent): void {
-        const {container, behaviour: {startThreshold}} = this._options;
-        const {x1, y1} = this._areaLocation; // Coordinates of the first "tap"
-        const {x, y} = simplifyEvent(evt);
+        const { container, behaviour: { startThreshold } } = this._options;
+        const { x1, y1 } = this._areaLocation; // Coordinates of the first "tap"
+        const { x, y } = simplifyEvent(evt);
 
         // Check the pixel threshold
         if (
@@ -428,12 +428,12 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
             (typeof startThreshold === 'object' && abs(x - x1) >= (startThreshold as Coordinates).x || abs(y - y1) >= (startThreshold as Coordinates).y)
         ) {
             // For shadow roots, we need to unbind from both shadow root and main document
-            const {document: docOpt1} = this._options;
+            const { document: docOpt1 } = this._options;
             const eventTarget = docOpt1 instanceof ShadowRoot ? docOpt1 : getDocument(docOpt1);
             const mainDocument = getDocument(docOpt1);
-            
-            off(eventTarget, ['mousemove', 'touchmove'], this._delayedTapMove, {passive: false});
-            off(mainDocument, ['mousemove', 'touchmove'], this._delayedTapMove, {passive: false});
+
+            off(eventTarget, ['mousemove', 'touchmove'], this._delayedTapMove, { passive: false });
+            off(mainDocument, ['mousemove', 'touchmove'], this._delayedTapMove, { passive: false });
 
             if (this._emitEvent('beforedrag', evt) === false) {
                 off(eventTarget, ['mouseup', 'touchcancel', 'touchend'], this._onTapStop);
@@ -441,23 +441,23 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
                 return;
             }
 
-            on(eventTarget, ['mousemove', 'touchmove'], this._onTapMove, {passive: false});
-            on(mainDocument, ['mousemove', 'touchmove'], this._onTapMove, {passive: false});
+            on(eventTarget, ['mousemove', 'touchmove'], this._onTapMove, { passive: false });
+            on(mainDocument, ['mousemove', 'touchmove'], this._onTapMove, { passive: false });
 
             // Make area element visible
             css(this._area, 'display', 'block');
 
             // Append selection-area to the dom
             // For shadow roots, append to the main document body to avoid transform issues
-            const {document: docOpt2} = this._options;
+            const { document: docOpt2 } = this._options;
             let containerElement = selectAll(container, docOpt2)[0];
-            
+
             // For shadow roots, always append to the main document body
             // to avoid transform coordinate system issues
             if (docOpt2 instanceof ShadowRoot) {
                 containerElement = getDocument(docOpt2).body;
             }
-            
+
             if (containerElement) {
                 containerElement.appendChild(this._clippingElement);
             } else {
@@ -480,10 +480,10 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
             if (this._scrollAvailable) {
 
                 // Detect mouse scrolling
-                on(this._targetElement, 'wheel', this._wheelScroll, {passive: false});
+                on(this._targetElement, 'wheel', this._wheelScroll, { passive: false });
 
                 // Detect keyboard scrolling
-                on(this._options.document, 'keydown', this._keyboardScroll, {passive: false});
+                on(this._options.document, 'keydown', this._keyboardScroll, { passive: false });
 
                 /**
                  * The selection-area will also cover another element
@@ -491,15 +491,15 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
                  * that are in the current scrollable element. Now these are
                  * the only selectables instead of all.
                  */
-                
+
                 // Special handling for shadow roots with transformed elements
-                const {document: doc} = this._options;
+                const { document: doc } = this._options;
                 if (doc instanceof ShadowRoot) {
                     // For shadow roots, if we have a start area that's different from the boundary,
                     // we should filter based on the start area instead of the boundary
                     const resolvedStartAreas = selectAll(this._options.startAreas, doc);
                     const startArea = resolvedStartAreas[0];
-                    
+
                     if (startArea && startArea !== this._targetElement) {
                         this._selectables = this._selectables.filter(s => startArea.contains(s));
                     } else {
@@ -507,7 +507,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
                         // we need to handle the case where selectables are in a transformed child
                         // Look for transformed elements within the target that might contain selectables
                         const transformedChildren = Array.from(this._targetElement!.querySelectorAll('[style*="transform"]'));
-                        
+
                         if (transformedChildren.length > 0) {
                             // Use the first transformed child as the containment reference
                             const transformedChild = transformedChildren[0];
@@ -523,7 +523,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
                     // Original logic for regular documents
                     this._selectables = this._selectables.filter(s => this._targetElement!.contains(s));
                 }
-                
+
 
             }
 
@@ -537,7 +537,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
     }
 
     _setupSelectionArea(): void {
-        const {_clippingElement, _targetElement, _area} = this;
+        const { _clippingElement, _targetElement, _area } = this;
         const tr = this._targetRect = _targetElement!.getBoundingClientRect();
 
         if (this._scrollAvailable) {
@@ -581,11 +581,11 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
     }
 
     _onTapMove(evt: MouseEvent | TouchEvent): void {
-        const {_scrollSpeed, _areaLocation, _options, _frame} = this;
-        const {speedDivider} = _options.behaviour.scrolling;
+        const { _scrollSpeed, _areaLocation, _options, _frame } = this;
+        const { speedDivider } = _options.behaviour.scrolling;
         const _targetElement = this._targetElement as Element;
 
-        const {x, y} = simplifyEvent(evt);
+        const { x, y } = simplifyEvent(evt);
         _areaLocation.x2 = x;
         _areaLocation.y2 = y;
 
@@ -604,7 +604,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
                 }
 
                 // Reduce velocity, use ceil in both directions to scroll at least 1px per frame
-                const {scrollTop, scrollLeft} = _targetElement;
+                const { scrollTop, scrollLeft } = _targetElement;
 
                 if (_scrollSpeed.y) {
                     _targetElement.scrollTop += ceil(_scrollSpeed.y / speedDivider);
@@ -642,7 +642,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
     }
 
     _handleMoveEvent(evt: MouseEvent | TouchEvent) {
-        const {features} = this._options;
+        const { features } = this._options;
 
         /**
          * - Prevent auto-refresh for when pulling down on touch devices.
@@ -654,9 +654,9 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
     }
 
     _onScroll(): void {
-        const {_scrollDelta, _options: {document: doc}} = this;
+        const { _scrollDelta, _options: { document: doc } } = this;
         const scrollElement = getScrollingElement(doc);
-        const {scrollTop, scrollLeft} = scrollElement;
+        const { scrollTop, scrollLeft } = scrollElement;
 
         // Adjust area start location
         this._areaLocation.x1 += _scrollDelta.x - scrollLeft;
@@ -675,7 +675,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
     }
 
     _wheelScroll(evt: ScrollEvent): void {
-        const {manualSpeed} = this._options.behaviour.scrolling;
+        const { manualSpeed } = this._options.behaviour.scrolling;
 
         // Consistent scrolling speed on all browsers
         const deltaY = evt.deltaY ? (evt.deltaY > 0 ? 1 : -1) : 0;
@@ -689,7 +689,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
     }
 
     _keyboardScroll(evt: KeyboardEvent): void {
-        const {manualSpeed} = this._options.behaviour.scrolling;
+        const { manualSpeed } = this._options.behaviour.scrolling;
 
         const deltaX = evt.key === 'ArrowLeft' ? -1 : evt.key === 'ArrowRight' ? 1 : 0;
         const deltaY = evt.key === 'ArrowUp' ? -1 : evt.key === 'ArrowDown' ? 1 : 0;
@@ -707,16 +707,16 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
     }
 
     _recalculateSelectionAreaRect(): void {
-        const {_scrollSpeed, _areaLocation, _targetElement, _options} = this;
-        const {scrollTop, scrollHeight, clientHeight, scrollLeft, scrollWidth, clientWidth} = _targetElement as Element;
+        const { _scrollSpeed, _areaLocation, _targetElement, _options } = this;
+        const { scrollTop, scrollHeight, clientHeight, scrollLeft, scrollWidth, clientWidth } = _targetElement as Element;
         const _targetRect = this._targetRect as DOMRect;
 
-        const {x1, y1} = _areaLocation;
-        let {x2, y2} = _areaLocation;
+        const { x1, y1 } = _areaLocation;
+        let { x2, y2 } = _areaLocation;
 
 
 
-        const {behaviour: {scrolling: {startScrollMargins}}} = _options;
+        const { behaviour: { scrolling: { startScrollMargins } } } = _options;
 
         if (x2 < _targetRect.left + startScrollMargins.x) {
             _scrollSpeed.x = scrollLeft ? -abs(_targetRect.left - x2 + startScrollMargins.x) : 0;
@@ -747,8 +747,8 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
     }
 
     _redrawSelectionArea(): void {
-        const {x, y, width, height} = this._areaRect;
-        const {style} = this._area;
+        const { x, y, width, height } = this._areaRect;
+        const { style } = this._area;
 
         // Using transform will make the area's borders look blurry
         style.left = `${x}px`;
@@ -760,8 +760,8 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
     }
 
     _onTapStop(evt: MouseEvent | TouchEvent | null, silent: boolean): void {
-        const {document: doc, features} = this._options;
-        const {_singleClick} = this;
+        const { document: doc, features } = this._options;
+        const { _singleClick } = this;
 
         // Remove event handlers
         off(this._targetElement, 'scroll', this._onStartAreaScroll);
@@ -769,7 +769,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
         // For regular documents, we unbind from the document
         const eventTarget = doc instanceof ShadowRoot ? doc : getDocument(doc);
         const mainDocument = getDocument(doc);
-        
+
         off(eventTarget, ['mousemove', 'touchmove'], this._delayedTapMove);
         off(mainDocument, ['mousemove', 'touchmove'], this._delayedTapMove);
         off(eventTarget, ['touchmove', 'mousemove'], this._onTapMove);
@@ -777,7 +777,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
         off(eventTarget, ['mouseup', 'touchcancel', 'touchend'], this._onTapStop);
         off(mainDocument, ['mouseup', 'touchcancel', 'touchend'], this._onTapStop);
         off(eventTarget, 'scroll', this._onScroll);
-        
+
         // For shadow roots, also unbind from the shadow host
         if (doc instanceof ShadowRoot) {
             off(doc.host, ['mousemove', 'touchmove'], this._delayedTapMove);
@@ -799,10 +799,10 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
         this._scrollSpeed.y = 0;
 
         // Unbind mouse scrolling listener
-        off(this._targetElement, 'wheel', this._wheelScroll, {passive: true});
+        off(this._targetElement, 'wheel', this._wheelScroll, { passive: true });
 
         // Unbind keyboard scrolling listener
-        off(this._options.document, 'keydown', this._keyboardScroll, {passive: true,});
+        off(this._options.document, 'keydown', this._keyboardScroll, { passive: true, });
 
         // Remove selection-area from dom
         this._clippingElement.remove();
@@ -815,9 +815,9 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
     }
 
     _updateElementSelection(): void {
-        const {_selectables, _options, _selection, _areaRect} = this;
-        const {stored, selected, touched} = _selection;
-        const {intersect, overlap} = _options.behaviour;
+        const { _selectables, _options, _selection, _areaRect } = this;
+        const { stored, selected, touched } = _selection;
+        const { intersect, overlap } = _options.behaviour;
 
         const invert = overlap === 'invert';
         const newlyTouched: Element[] = [];
@@ -875,7 +875,7 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
         }
 
         _selection.selected = newlyTouched;
-        _selection.changed = {added, removed};
+        _selection.changed = { added, removed };
 
         // Prevent range selection when selection an area.
         this._latestElement = undefined;
@@ -890,8 +890,8 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
     }
 
     _keepSelection(): void {
-        const {_options, _selection} = this;
-        const {selected, changed, touched, stored} = _selection;
+        const { _options, _selection } = this;
+        const { selected, changed, touched, stored } = _selection;
         const addedElements = selected.filter(el => !stored.includes(el));
 
         switch (_options.behaviour.overlap) {
@@ -940,9 +940,10 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
      * Same as deselecting, but for all elements currently selected
      * @param includeStored If the store should also get cleared
      * @param quiet If move / stop events should be fired
+     * @param event The event that triggered the clear selection
      */
-    clearSelection(includeStored = true, quiet = false): void {
-        const {selected, stored, changed} = this._selection;
+    clearSelection(includeStored = true, quiet = false, event: MouseEvent | TouchEvent | null = null): void {
+        const { selected, stored, changed } = this._selection;
 
         changed.added = [];
         changed.removed.push(
@@ -952,8 +953,9 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
 
         // Fire event
         if (!quiet) {
-            this._emitEvent('move', null);
-            this._emitEvent('stop', null);
+            this._emitEvent('start', event);
+            this._emitEvent('move', event);
+            this._emitEvent('stop', event);
         }
 
         // Reset state
@@ -1030,8 +1032,8 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
      * @param query CSS Query, can be an array of queries
      * @param quiet If this should not trigger the move event
      */
-    select(query: SelectAllSelectors, quiet = false): Element[] {
-        const {changed, selected, stored} = this._selection;
+    select(query: SelectAllSelectors, quiet = false, event: MouseEvent | TouchEvent | null = null): Element[] {
+        const { changed, selected, stored } = this._selection;
         const elements = selectAll(query, this._options.document).filter(el =>
             !selected.includes(el) &&
             !stored.includes(el)
@@ -1048,8 +1050,8 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
 
         // Fire event
         if (!quiet) {
-            this._emitEvent('move', null);
-            this._emitEvent('stop', null);
+            this._emitEvent('move', event);
+            this._emitEvent('stop', event);
         }
 
         return elements;
@@ -1060,8 +1062,8 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
      * @param query CSS Query, can be an array of queries
      * @param quiet If this should not trigger the move event
      */
-    deselect(query: SelectAllSelectors, quiet = false) {
-        const {selected, stored, changed} = this._selection;
+    deselect(query: SelectAllSelectors, quiet = false, event: MouseEvent | TouchEvent | null = null) {
+        const { selected, stored, changed } = this._selection;
 
         const elements = selectAll(query, this._options.document).filter(el =>
             selected.includes(el) ||
@@ -1080,8 +1082,8 @@ export default class SelectionArea extends EventTarget<SelectionEvents> {
 
         // Fire event
         if (!quiet) {
-            this._emitEvent('move', null);
-            this._emitEvent('stop', null);
+            this._emitEvent('move', event);
+            this._emitEvent('stop', event);
         }
     }
 }

--- a/packages/vanilla/src/types.ts
+++ b/packages/vanilla/src/types.ts
@@ -17,12 +17,6 @@ export interface DocumentOrShadowRoot {
     getElementById(elementId: string): HTMLElement | null;
 }
 
-// Extend Document and ShadowRoot to include the common interface
-declare global {
-    interface Document extends DocumentOrShadowRoot {}
-    interface ShadowRoot extends DocumentOrShadowRoot {}
-}
-
 export interface ScrollEvent extends MouseEvent {
     deltaY: number;
     deltaX: number;

--- a/packages/vanilla/src/types.ts
+++ b/packages/vanilla/src/types.ts
@@ -9,6 +9,20 @@ export type DeepPartial<T> =
 
 export type Quantify<T> = T[] | T;
 
+// Common interface for Document and ShadowRoot operations
+// Note: ShadowRoot doesn't have createElement - that's a Document method
+export interface DocumentOrShadowRoot {
+    querySelector(selectors: string): Element | null;
+    querySelectorAll(selectors: string): NodeListOf<Element>;
+    getElementById(elementId: string): HTMLElement | null;
+}
+
+// Extend Document and ShadowRoot to include the common interface
+declare global {
+    interface Document extends DocumentOrShadowRoot {}
+    interface ShadowRoot extends DocumentOrShadowRoot {}
+}
+
 export interface ScrollEvent extends MouseEvent {
     deltaY: number;
     deltaX: number;
@@ -86,7 +100,7 @@ export interface SelectionOptions {
     selectionContainerClass: string | undefined;
     container: Quantify<string | HTMLElement>;
 
-    document: Document;
+    document: Document | ShadowRoot;
     selectables: Quantify<string>;
 
     startAreas: Quantify<string | HTMLElement>;
@@ -97,5 +111,5 @@ export interface SelectionOptions {
 }
 
 export type PartialSelectionOptions = DeepPartial<Omit<SelectionOptions, 'document'>> & {
-    document?: Document;
+    document?: Document | ShadowRoot;
 };

--- a/packages/vanilla/src/utils/events.ts
+++ b/packages/vanilla/src/utils/events.ts
@@ -58,5 +58,18 @@ export const simplifyEvent = (evt: any): {
     y: number;
 } => {
     const {clientX, clientY, target} = evt.touches?.[0] ?? evt;
-    return {x: clientX, y: clientY, target};
+    
+    // Ensure target is an HTMLElement
+    let htmlTarget: HTMLElement;
+    if (target instanceof HTMLElement) {
+        htmlTarget = target;
+    } else if (target instanceof Element) {
+        // If it's an Element but not HTMLElement, try to cast it
+        htmlTarget = target as HTMLElement;
+    } else {
+        // Fallback to document.body if target is not a valid element
+        htmlTarget = document.body;
+    }
+    
+    return {x: clientX, y: clientY, target: htmlTarget};
 };

--- a/packages/vanilla/src/utils/intersects.ts
+++ b/packages/vanilla/src/utils/intersects.ts
@@ -8,27 +8,34 @@ export type Intersection = 'center' | 'cover' | 'touch';
  * @returns {boolean} If both elements intersects each other.
  */
 export const intersects = (a: DOMRect, b: DOMRect, mode: Intersection = 'touch'): boolean => {
+        let result: boolean;
+
     switch (mode) {
         case 'center': {
             const bxc = b.left + b.width / 2;
             const byc = b.top + b.height / 2;
 
-            return bxc >= a.left &&
+            result = bxc >= a.left &&
                 bxc <= a.right &&
                 byc >= a.top &&
                 byc <= a.bottom;
+            break;
         }
         case 'cover': {
-            return b.left >= a.left &&
+            result = b.left >= a.left &&
                 b.top >= a.top &&
                 b.right <= a.right &&
                 b.bottom <= a.bottom;
+            break;
         }
         case 'touch': {
-            return a.right >= b.left &&
+            result = a.right >= b.left &&
                 a.left <= b.right &&
                 a.bottom >= b.top &&
                 a.top <= b.bottom;
+            break;
         }
     }
+
+    return result;
 };

--- a/packages/vanilla/src/utils/selectAll.ts
+++ b/packages/vanilla/src/utils/selectAll.ts
@@ -8,7 +8,7 @@ export type SelectAllSelectors = (string | Element)[] | string | Element;
  * @param doc
  * @returns {Array} Array of DOM-Nodes.
  */
-export const selectAll = (selector: SelectAllSelectors, doc: Document = document): Element[] =>
+export const selectAll = (selector: SelectAllSelectors, doc: Document | ShadowRoot = document): Element[] =>
     arrayify(selector)
         .map(item =>
             typeof item === 'string'


### PR DESCRIPTION
- Updated the API reference to allow `document` to accept both `Document` and `ShadowRoot`.
- Added notes on handling events and element creation in shadow contexts.


Note: Some of the changes where LLM generated, but I manually edited and tested it.

<img width="1092" height="723" alt="image" src="https://github.com/user-attachments/assets/265c710c-b3d4-4f13-b8b5-341f202052d4" />
