### PR TITLE
Mention `quiet` when documenting null-event SelectionEvents

### DIFF
--- a/docs/pages/api-reference.md
+++ b/docs/pages/api-reference.md
@@ -371,7 +371,7 @@ interface SelectionEvent {
 }
 ```
 
-- `event` - The original event that triggered the selection, may be `null` if manually triggered.
+- `event` - The original event that triggered the selection, may be `null` if manually triggered. Set `quiet` to true in manual selection functions to prevent firing the event. (see `clearSelection`, `select` or `unselect`)
 - `store` - The current state of the selection store.
 - `selection` - The selection area instance.
 


### PR DESCRIPTION
I wondered where these came from, ended up searching through the code source (it was quite easy mind you, which means the code base is not too bad :p)

The solution was to set `quiet` to true on my functions.